### PR TITLE
Fixed uninitialized value Message in MasterSlave.pm

### DIFF
--- a/Kernel/System/DynamicField/Driver/MasterSlave.pm
+++ b/Kernel/System/DynamicField/Driver/MasterSlave.pm
@@ -344,7 +344,7 @@ sub PossibleValuesGet {
 
     # If config UnsetMasterSlave is enabled and we are requesting values from AdminGenericAgent,
     #   add UnsetMaster and UnsetSlave possible values. See bug#14778 (https://bugs.otrs.org/show_bug.cgi?id=14778).
-    if ( $ConfigObject->Get('MasterSlave::UnsetMasterSlave') && $Param{LayoutObject}->{Action} eq 'AdminGenericAgent' )
+    if ( $ConfigObject->Get('MasterSlave::UnsetMasterSlave') && $LayoutObject->{Action} eq 'AdminGenericAgent' )
     {
         $PossibleValues{UnsetMaster} = $LayoutObject->{LanguageObject}->Translate('Unset Master Ticket');
         $PossibleValues{UnsetSlave}  = $LayoutObject->{LanguageObject}->Translate('Unset Slave Ticket');


### PR DESCRIPTION
use $LayoutObject->{Action}  instead of uninitialized (historical and now empty) $Param{LayoutObject}