### PR TITLE
Fixed missing attachments from primary in secondary

### DIFF
--- a/Kernel/System/Ticket/Event/PrimarySecondary.pm
+++ b/Kernel/System/Ticket/Event/PrimarySecondary.pm
@@ -395,6 +395,24 @@ sub Run {
             return 1;
         }
 
+        # Get attachments in primary for usage in secondary tickets.
+        my %AttachmentIndex = $ArticleBackendObject->ArticleAttachmentIndex(
+            ArticleID => $Articles[-1]->{ArticleID},
+        );
+
+        my @Attachments;
+        ATTACHMENT:
+        for my $FileID ( sort keys %AttachmentIndex ) {
+            next ATTACHMENT if !$FileID;
+            my %Attachment = $ArticleBackendObject->ArticleAttachment(
+                ArticleID => $Articles[-1]->{ArticleID},
+                FileID    => $FileID,
+            );
+
+            next ATTACHMENT if !IsHashRefWithData( \%Attachment );
+            push @Attachments, {%Attachment};
+        }
+
         # perform action on linked tickets
         TICKETID:
         for my $TicketID (@TicketIDs) {
@@ -412,6 +430,7 @@ sub Run {
                 HistoryComment => 'Added article based on primary ticket.',
                 TicketID       => $TicketID,
                 UserID         => $Param{UserID},
+                Attachment     => \@Attachments,
             );
         }
 


### PR DESCRIPTION
The article attachments are not carried over to the secondary if an internal note is created in the primary.
This also means, that the article itself in the secondary is plain text instead of HTML.

![image](https://github.com/znuny/Znuny-PrimarySecondary/assets/80031303/61888ef0-36c7-4f95-95d1-6d9f4a2fb53d)
